### PR TITLE
Add Fathom analytics to our landingpage and remove dApps Built on PsyOptions section

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -40,6 +40,7 @@ const Header = () => {
   return(
     <IconContext.Provider value={{ color: "#fff"}}>
       <nav className={`header ${(showMobileMenu) ? 'show-nav' : 'hide-nav'}`}>
+        <script src="https://cdn.usefathom.com/script.js" data-site="QFVSOIRZ" defer></script>
         <div className="header-logo">
           <Link to="/"><img src={companyLogo} alt="PsyOptions Logo Icon" /></Link>
         </div>

--- a/src/components/IndexRelationships.js
+++ b/src/components/IndexRelationships.js
@@ -1,8 +1,5 @@
 import React from "react";
 import "../styles/IndexRelationships.scss";
-import LogoD2 from "../images/tap-finance.png";
-import LogoD3 from "../images/katana.png";
-import LogoD4 from "../images/chest.jpg";
 import LogoI1 from "../images/alameda.png";
 import LogoI2 from "../images/solana.jpg";
 import LogoI3 from "../images/gbv.jpg";
@@ -18,22 +15,6 @@ import ProtoFundLogo from "../images/protofund_logo.png";
 const Relationships = () => {
   return (
     <div className="relationships">
-      <h1>Dapps Built on PsyOptions</h1>
-      <div className="r-grid">
-        {/* additional content in follow-up release */}
-        <div>
-          <img src={LogoD2} alt="Tap Finance, a dapp built on PsyOptions"/>
-          <div>Tap Finance</div>
-        </div>
-        <div>
-          <img src={LogoD3} alt="Katana, a dapp built on PsyOptions"/>
-          <div>Katana</div>
-        </div>
-        <div>
-          <img src={LogoD4} alt="Chest, a dapp built on PsyOptions"/>
-          <div>Chest</div>
-        </div>
-      </div>
     <h1>Investors</h1>
       <div className="r-grid">
         {/* additional content in follow-up release */}


### PR DESCRIPTION
Fathom Analytics is a privacy focused, Google Analytics alternative. By adding this script to our landing page header, we will be able to gather user data without relying on cookie banners. Additionally, Fathom bypasses ad blockers

More information here: https://usefathom.com/how-fathom-analytics-works